### PR TITLE
Replace deprecated `prospector` with `input`

### DIFF
--- a/module/exim4/main/manifest.yml
+++ b/module/exim4/main/manifest.yml
@@ -8,4 +8,4 @@ var:
     os.windows: []
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/main.yml
+input: config/main.yml

--- a/module/exim4/reject/manifest.yml
+++ b/module/exim4/reject/manifest.yml
@@ -8,4 +8,4 @@ var:
     os.windows: []
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/reject.yml
+input: config/reject.yml


### PR DESCRIPTION
Ensures compatibility with Filebeat 7.0, closes #4 